### PR TITLE
Correction Node.js version < 0.10.xx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "sgs-communication",
 	"private": true,
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Sagacify's communication module. Support's both Email and SMS's.",
 	"main": "src/sgs-communication.js",
 	"scripts": {

--- a/src/EmailSender.js
+++ b/src/EmailSender.js
@@ -10,7 +10,7 @@ var NodemailerHtmlToText = require('nodemailer-html-to-text').htmlToText;
 
 // If Node.js version < 0.10.xx, we use the `readable-stream` module
 // as a shim for the core `stream` module.
-if (+process.versions.node.split('.').join('') < 1000) {
+if (+process.versions.node.match(/^(\d+.\d+).\d+$/)[1] < 0.10) {
 	require('readable-stream');
 }
 


### PR DESCRIPTION
Il y avait un petit soucis dans la condition Node.js version < 0.10.xx, quand la version de Node.js est de la forme 0.xx.x, au lieu de 0.xx.xx. Par exemple, pour 0.12.0, cela donne 120 < 1000 (alors qu'on voudrait 1200 < 1000).

J'ai fait plutôt une regex pour prendre la partie du numéro de version qui nous intéresse.
